### PR TITLE
Set new version of eclipse jdt.ls

### DIFF
--- a/org-eclipse-che-jdt-ls-extension/pom.xml
+++ b/org-eclipse-che-jdt-ls-extension/pom.xml
@@ -147,7 +147,7 @@
                         <artifact>
                             <groupId>org.eclipse.jdt.ls</groupId>
                             <artifactId>org.eclipse.jdt.ls.tp</artifactId>
-                            <version>0.12.0-SNAPSHOT</version>
+                            <version>0.12.1-SNAPSHOT</version>
                         </artifact>
                     </target>
                     <environments>


### PR DESCRIPTION
Signed-off-by: Valeriy Svydenko <vsvydenk@redhat.com>

Upgrades the version of org.eclipse.jdt.ls to 0.12.1-SNAPSHOT