### PR TITLE
Removed unneeded additional license header

### DIFF
--- a/org-eclipse-che-jdt-ls-extension/jdt.ls.extension.core/src/main/java/org/eclipse/che/jdt/ls/extension/core/internal/classpath/ResolveClassPathsHandler.java
+++ b/org-eclipse-che-jdt-ls-extension/jdt.ls.extension.core/src/main/java/org/eclipse/che/jdt/ls/extension/core/internal/classpath/ResolveClassPathsHandler.java
@@ -8,16 +8,6 @@
  * Contributors:
  *   Red Hat, Inc. - initial API and implementation
  */
-/*
- * Copyright (c) 2012-2017 Red Hat, Inc.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
- *
- * Contributors:
- *   Red Hat, Inc. - initial API and implementation
- */
 package org.eclipse.che.jdt.ls.extension.core.internal.classpath;
 
 import static java.util.Collections.emptyList;


### PR DESCRIPTION
It looks like an additional license header snuck through, I removed the 2012-2017 one and kept the 2012-2018 one