### PR TITLE
Set dependency to a new eclipse.jdt.ls 0.15.0-SNAPSHOT version

### DIFF
--- a/org-eclipse-che-jdt-ls-extension/pom.xml
+++ b/org-eclipse-che-jdt-ls-extension/pom.xml
@@ -147,7 +147,7 @@
                         <artifact>
                             <groupId>org.eclipse.jdt.ls</groupId>
                             <artifactId>org.eclipse.jdt.ls.tp</artifactId>
-                            <version>0.14.0-SNAPSHOT</version>
+                            <version>0.15.0-SNAPSHOT</version>
                         </artifact>
                     </target>
                     <environments>


### PR DESCRIPTION
Set dependency to a new eclipse.jdt.ls 0.15.0-SNAPSHOT version