### PR TITLE
Support Move refactoring

### DIFF
--- a/org-eclipse-che-jdt-ls-extension/jdt.ls.extension.api/src/main/java/org/eclipse/che/jdt/ls/extension/api/Commands.java
+++ b/org-eclipse-che-jdt-ls-extension/jdt.ls.extension.api/src/main/java/org/eclipse/che/jdt/ls/extension/api/Commands.java
@@ -86,11 +86,18 @@ public class Commands {
 
   public static final String RENAME_COMMAND = "che.jdt.ls.extension.refactoring.rename";
   public static final String GET_RENAME_TYPE_COMMAND =
-      "che.jdt.ls.extension.refactoring.get.rename.type";
+      "che.jdt.ls.extension.refactoring.rename.get.type";
   public static final String VALIDATE_RENAMED_NAME_COMMAND =
-      "che.jdt.ls.extension.refactoring.validate.renamed.name";
+      "che.jdt.ls.extension.refactoring.rename.validate.new.name";
   public static final String GET_LINKED_ELEMENTS_COMMAND =
-      "che.jdt.ls.extension.refactoring.get.linked.elements";
+      "che.jdt.ls.extension.refactoring.rename.get.linked.elements";
+  public static final String VALIDATE_MOVE_COMMAND =
+      "che.jdt.ls.extension.refactoring.move.validate";
+  public static final String GET_DESTINATIONS_COMMAND =
+      "che.jdt.ls.extension.refactoring.move.get.destinations.command";
+  public static final String MOVE_COMMAND = "che.jdt.ls.extension.refactoring.move.command";
+  public static final String VERIFY_MOVE_DESTINATION_COMMAND =
+      "che.jdt.ls.extension.refactoring.move.verify.destination";
 
   // CLASSPATH updater
   public static final String CLIENT_UPDATE_PROJECTS_CLASSPATH =

--- a/org-eclipse-che-jdt-ls-extension/jdt.ls.extension.api/src/main/java/org/eclipse/che/jdt/ls/extension/api/dto/CreateMoveParams.java
+++ b/org-eclipse-che-jdt-ls-extension/jdt.ls.extension.api/src/main/java/org/eclipse/che/jdt/ls/extension/api/dto/CreateMoveParams.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.jdt.ls.extension.api.dto;
+
+import java.util.List;
+
+/**
+ * Object describes initialization of the move refactoring operation.
+ *
+ * @author Valeriy Svydenko
+ */
+public class CreateMoveParams {
+  private String projectUri;
+  private List<Resource> resources;
+
+  /** Returns URI of the project */
+  public String getProjectUri() {
+    return projectUri;
+  }
+
+  public void setProjectUri(String projectUri) {
+    this.projectUri = projectUri;
+  }
+
+  /** Returns list of the elements to be moved. */
+  public List<Resource> getResources() {
+    return resources;
+  }
+
+  public void setResources(List<Resource> resources) {
+    this.resources = resources;
+  }
+}

--- a/org-eclipse-che-jdt-ls-extension/jdt.ls.extension.api/src/main/java/org/eclipse/che/jdt/ls/extension/api/dto/JavaProjectStructure.java
+++ b/org-eclipse-che-jdt-ls-extension/jdt.ls.extension.api/src/main/java/org/eclipse/che/jdt/ls/extension/api/dto/JavaProjectStructure.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.jdt.ls.extension.api.dto;
+
+import java.util.List;
+
+/**
+ * Represents Java project in terms of JavaModel.
+ *
+ * @author Valeriy Svydenko
+ */
+public class JavaProjectStructure {
+  private String uri;
+  private String name;
+  private List<PackageFragmentRoot> packageRoots;
+
+  /**
+   * Get all package fragment roots from this project.
+   *
+   * @return list of the package fragment roots
+   */
+  public List<PackageFragmentRoot> getPackageRoots() {
+    return packageRoots;
+  }
+
+  public void setPackageRoots(List<PackageFragmentRoot> packageRoots) {
+    this.packageRoots = packageRoots;
+  }
+
+  /** Returns project's uri. */
+  public String getUri() {
+    return uri;
+  }
+
+  public void setUri(String uri) {
+    this.uri = uri;
+  }
+
+  /** Returns project's name. */
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+}

--- a/org-eclipse-che-jdt-ls-extension/jdt.ls.extension.api/src/main/java/org/eclipse/che/jdt/ls/extension/api/dto/MoveSettings.java
+++ b/org-eclipse-che-jdt-ls-extension/jdt.ls.extension.api/src/main/java/org/eclipse/che/jdt/ls/extension/api/dto/MoveSettings.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.jdt.ls.extension.api.dto;
+
+import java.util.List;
+
+/**
+ * Describes settings of Move refactoring operation.
+ *
+ * @author Valeriy Svydenko
+ */
+public class MoveSettings {
+  private String destination;
+  private List<Resource> elements;
+  private boolean updateReferences;
+  private boolean updateQualifiedNames;
+  private String filePatterns;
+
+  /** Returns URI of resource which was selected to be destination. */
+  public String getDestination() {
+    return destination;
+  }
+
+  public void setDestination(String destination) {
+    this.destination = destination;
+  }
+
+  /** Returns elements that will be moved. */
+  public List<Resource> getElements() {
+    return elements;
+  }
+
+  public void setElements(List<Resource> elements) {
+    this.elements = elements;
+  }
+
+  /** @return true if refactoring should update references in classes, false otherwise */
+  public boolean isUpdateReferences() {
+    return updateReferences;
+  }
+
+  public void setUpdateReferences(boolean updateReferences) {
+    this.updateReferences = updateReferences;
+  }
+
+  /** Used to ask the refactoring object whether references in non Java files should be updated. */
+  public boolean isUpdateQualifiedNames() {
+    return updateQualifiedNames;
+  }
+
+  public void setUpdateQualifiedNames(boolean updateQualifiedNames) {
+    this.updateQualifiedNames = updateQualifiedNames;
+  }
+
+  /**
+   * if {@link #isUpdateQualifiedNames()} return true refactoring will use this file pattern to
+   * search qualified names
+   *
+   * @return the file pattern
+   */
+  public String getFilePatterns() {
+    return filePatterns;
+  }
+
+  public void setFilePatterns(String filePatterns) {
+    this.filePatterns = filePatterns;
+  }
+}

--- a/org-eclipse-che-jdt-ls-extension/jdt.ls.extension.api/src/main/java/org/eclipse/che/jdt/ls/extension/api/dto/PackageFragment.java
+++ b/org-eclipse-che-jdt-ls-extension/jdt.ls.extension.api/src/main/java/org/eclipse/che/jdt/ls/extension/api/dto/PackageFragment.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.jdt.ls.extension.api.dto;
+
+/**
+ * Represents package fragment.
+ *
+ * @author Valeriy Svydenko
+ */
+public class PackageFragment {
+  private String uri;
+  private String projectUri;
+  private boolean defaultPackage;
+  private String name;
+
+  /** Returns uri of the resource. */
+  public String getUri() {
+    return uri;
+  }
+
+  public void setUri(String uri) {
+    this.uri = uri;
+  }
+
+  /** Returns whether this package fragment is a default package. This is a handle-only method. */
+  public boolean isDefaultPackage() {
+    return defaultPackage;
+  }
+
+  public void setDefaultPackage(boolean defaultPackage) {
+    this.defaultPackage = defaultPackage;
+  }
+
+  /** Returns the name of this element. This is a handle-only method. */
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  /** Returns project uri. */
+  public String getProjectUri() {
+    return projectUri;
+  }
+
+  public void setProjectUri(String projectUri) {
+    this.projectUri = projectUri;
+  }
+}

--- a/org-eclipse-che-jdt-ls-extension/jdt.ls.extension.api/src/main/java/org/eclipse/che/jdt/ls/extension/api/dto/PackageFragmentRoot.java
+++ b/org-eclipse-che-jdt-ls-extension/jdt.ls.extension.api/src/main/java/org/eclipse/che/jdt/ls/extension/api/dto/PackageFragmentRoot.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.jdt.ls.extension.api.dto;
+
+import java.util.List;
+
+/**
+ * Represents package fragment root.
+ *
+ * @author Valeriy Svydenko
+ */
+public class PackageFragmentRoot {
+  private String uri;
+  private String projectUri;
+  private List<PackageFragment> packages;
+
+  /**
+   * All package fragments in this package fragment root.
+   *
+   * @return list of package fragments
+   */
+  public List<PackageFragment> getPackages() {
+    return packages;
+  }
+
+  public void setPackages(List<PackageFragment> packages) {
+    this.packages = packages;
+  }
+
+  /** Returns uri of the resource. */
+  public String getUri() {
+    return uri;
+  }
+
+  public void setUri(String uri) {
+    this.uri = uri;
+  }
+
+  /** Returns uri of the current project. */
+  public String getProjectUri() {
+    return projectUri;
+  }
+
+  public void setProjectUri(String projectUri) {
+    this.projectUri = projectUri;
+  }
+}

--- a/org-eclipse-che-jdt-ls-extension/jdt.ls.extension.api/src/main/java/org/eclipse/che/jdt/ls/extension/api/dto/RefactoringStatus.java
+++ b/org-eclipse-che-jdt-ls-extension/jdt.ls.extension.api/src/main/java/org/eclipse/che/jdt/ls/extension/api/dto/RefactoringStatus.java
@@ -18,7 +18,7 @@ import org.eclipse.che.jdt.ls.extension.api.RefactoringSeverity;
  *
  * @author Valeriy Svydenko
  */
-public class NameValidationStatus {
+public class RefactoringStatus {
   private List<RefactoringStatusEntry> refactoringStatusEntries;
   private RefactoringSeverity refactoringSeverity;
 

--- a/org-eclipse-che-jdt-ls-extension/jdt.ls.extension.api/src/main/java/org/eclipse/che/jdt/ls/extension/api/dto/Resource.java
+++ b/org-eclipse-che-jdt-ls-extension/jdt.ls.extension.api/src/main/java/org/eclipse/che/jdt/ls/extension/api/dto/Resource.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.jdt.ls.extension.api.dto;
+
+/**
+ * Represents a resource.
+ *
+ * @author Valeriy Svydenko
+ */
+public class Resource {
+  private String uri;
+  private boolean pack;
+
+  /** @return true if this resource is package and false if it's compilation unit */
+  public boolean isPack() {
+    return pack;
+  }
+
+  public void setPack(boolean pack) {
+    this.pack = pack;
+  }
+
+  /** @return uri of the resource */
+  public String getUri() {
+    return uri;
+  }
+
+  public void setUri(String uri) {
+    this.uri = uri;
+  }
+}

--- a/org-eclipse-che-jdt-ls-extension/jdt.ls.extension.core/META-INF/MANIFEST.MF
+++ b/org-eclipse-che-jdt-ls-extension/jdt.ls.extension.core/META-INF/MANIFEST.MF
@@ -5,6 +5,7 @@ Bundle-SymbolicName: jdt.ls.extension.core;singleton:=true
 Bundle-Version: 0.0.1.qualifier
 Bundle-Activator: org.eclipse.che.jdt.ls.extension.core.internal.ExtensionActivator
 Import-Package: com.google.common.base;version="15.0.0",
+ com.google.common.reflect;version="15.0.0",
  com.google.gson,
  org.apache.commons.io,
  org.apache.commons.lang3.tuple;version="3.1.0",
@@ -24,9 +25,7 @@ Import-Package: com.google.common.base;version="15.0.0",
  org.eclipse.ltk.core.refactoring,
  org.eclipse.ltk.core.refactoring.participants,
  org.eclipse.ltk.core.refactoring.resource,
- org.eclipse.ltk.internal.core.refactoring,
- org.eclipse.search.core.text,
- org.eclipse.jface.text
+ org.eclipse.ltk.internal.core.refactoring
 Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.jdt.core,
  org.eclipse.m2e.core,

--- a/org-eclipse-che-jdt-ls-extension/jdt.ls.extension.core/plugin.xml
+++ b/org-eclipse-che-jdt-ls-extension/jdt.ls.extension.core/plugin.xml
@@ -39,9 +39,13 @@
             <command id="che.jdt.ls.extension.configuration.updatePreferences"/>
             <command id="che.jdt.ls.extension.import.organizeImports"/>
             <command id="che.jdt.ls.extension.refactoring.rename"/>
-            <command id="che.jdt.ls.extension.refactoring.get.rename.type"/>
-            <command id="che.jdt.ls.extension.refactoring.validate.renamed.name"/>
-            <command id="che.jdt.ls.extension.refactoring.get.linked.elements"/>
+            <command id="che.jdt.ls.extension.refactoring.rename.get.type"/>
+            <command id="che.jdt.ls.extension.refactoring.rename.validate.new.name"/>
+            <command id="che.jdt.ls.extension.refactoring.rename.get.linked.elements"/>
+            <command id="che.jdt.ls.extension.refactoring.move.validate"/>
+            <command id="che.jdt.ls.extension.refactoring.move.get.destinations.command"/>
+            <command id="che.jdt.ls.extension.refactoring.move.command"/>
+            <command id="che.jdt.ls.extension.refactoring.move.verify.destination"/>
         </delegateCommandHandler>
     </extension>
     <extension

--- a/org-eclipse-che-jdt-ls-extension/jdt.ls.extension.core/src/main/java/org/eclipse/che/jdt/ls/extension/core/internal/ChangeUtil.java
+++ b/org-eclipse-che-jdt-ls-extension/jdt.ls.extension.core/src/main/java/org/eclipse/che/jdt/ls/extension/core/internal/ChangeUtil.java
@@ -8,7 +8,7 @@
  * Contributors:
  *   Red Hat, Inc. - initial API and implementation
  */
-package org.eclipse.che.jdt.ls.extension.core.internal.refactoring.rename;
+package org.eclipse.che.jdt.ls.extension.core.internal;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -33,13 +33,18 @@ import org.eclipse.jdt.core.dom.Javadoc;
 import org.eclipse.jdt.core.dom.Name;
 import org.eclipse.jdt.core.dom.PackageDeclaration;
 import org.eclipse.jdt.core.dom.rewrite.ASTRewrite;
+import org.eclipse.jdt.internal.core.manipulation.util.BasicElementLabels;
 import org.eclipse.jdt.internal.corext.dom.IASTSharedValues;
 import org.eclipse.jdt.internal.corext.util.JavaModelUtil;
 import org.eclipse.jdt.ls.core.internal.JDTUtils;
 import org.eclipse.jdt.ls.core.internal.JavaLanguageServerPlugin;
+import org.eclipse.jdt.ls.core.internal.Messages;
 import org.eclipse.jdt.ls.core.internal.ResourceUtils;
 import org.eclipse.jdt.ls.core.internal.TextEditConverter;
+import org.eclipse.jdt.ls.core.internal.corext.refactoring.RefactoringCoreMessages;
 import org.eclipse.jdt.ls.core.internal.corext.refactoring.changes.DynamicValidationRefactoringChange;
+import org.eclipse.jdt.ls.core.internal.corext.refactoring.changes.MoveCompilationUnitChange;
+import org.eclipse.jdt.ls.core.internal.corext.refactoring.changes.MovePackageChange;
 import org.eclipse.jdt.ls.core.internal.corext.refactoring.changes.RenameCompilationUnitChange;
 import org.eclipse.jdt.ls.core.internal.corext.refactoring.changes.RenamePackageChange;
 import org.eclipse.jdt.ls.core.internal.corext.refactoring.util.RefactoringASTParser;
@@ -114,7 +119,47 @@ public class ChangeUtil {
       convertCUResourceChange(edit, (RenameCompilationUnitChange) resourceChange);
     } else if (resourceChange instanceof RenamePackageChange) {
       convertRenamePackcageChange(edit, (RenamePackageChange) resourceChange);
+    } else if (resourceChange instanceof MoveCompilationUnitChange) {
+      convertMoveCUChange(edit, (MoveCompilationUnitChange) resourceChange);
+    } else if (resourceChange instanceof MovePackageChange) {
+      convertMovePackageChange(edit, (MovePackageChange) resourceChange);
     }
+  }
+
+  private static void convertMovePackageChange(
+      CheWorkspaceEdit edit, MovePackageChange packChange) {
+    CheResourceChange rc = new CheResourceChange();
+    rc.setResourceKind(ResourceKind.FOLDER);
+    IPath newPackageFragment =
+        new Path(packChange.getPackage().getElementName().replace('.', IPath.SEPARATOR));
+    String destinationUri = JDTUtils.getFileURI(packChange.getDestination().getResource());
+    rc.setNewUri(destinationUri + JDTUtils.PATH_SEPARATOR + newPackageFragment);
+    rc.setCurrent(JDTUtils.getFileURI(packChange.getPackage().getResource()));
+    rc.setDescription(packChange.getName());
+    edit.getCheResourceChanges().add(rc);
+  }
+
+  private static void convertMoveCUChange(CheWorkspaceEdit edit, MoveCompilationUnitChange cuChange)
+      throws JavaModelException {
+    ICompilationUnit modifiedCU = cuChange.getCu();
+    String name = modifiedCU.getElementName();
+    CheResourceChange rc = new CheResourceChange();
+    rc.setResourceKind(ResourceKind.FILE);
+    rc.setCurrent(JDTUtils.toURI(modifiedCU));
+    IPackageFragment destinationPackage = cuChange.getDestinationPackage();
+    String newPackageUri = JDTUtils.getFileURI(destinationPackage.getResource());
+    String newUri = newPackageUri + JDTUtils.PATH_SEPARATOR + name;
+    rc.setNewUri(newUri);
+    rc.setDescription(cuChange.getName());
+    edit.getCheResourceChanges().add(rc);
+
+    // update package
+    CompilationUnit unit =
+        new RefactoringASTParser(IASTSharedValues.SHARED_AST_LEVEL).parse(modifiedCU, true);
+    ASTRewrite rewrite = ASTRewrite.create(unit.getAST());
+    updatePackageStatement(unit, destinationPackage.getElementName(), rewrite, modifiedCU);
+    TextEdit textEdit = rewrite.rewriteAST();
+    convertTextEdit(edit, modifiedCU, textEdit);
   }
 
   private static void convertRenamePackcageChange(
@@ -151,6 +196,7 @@ public class ChangeUtil {
             .append(newPackageFragment);
     rc.setNewUri(ResourceUtils.fixURI(newPackagePath.toFile().toURI()));
     rc.setResourceKind(ResourceKind.FOLDER);
+    rc.setDescription(packageChange.getName());
     if (packageChange.getRenameSubpackages()) {
       rc.setCurrent(ResourceUtils.fixURI(pack.getResource().getRawLocationURI()));
       edit.getCheResourceChanges().add(rc);
@@ -162,6 +208,13 @@ public class ChangeUtil {
         cuResourceChange.setCurrent(ResourceUtils.fixURI(unit.getResource().getLocationURI()));
         IPath newCUPath = newPackagePath.append(unit.getPath().lastSegment());
         cuResourceChange.setNewUri(ResourceUtils.fixURI(newCUPath.toFile().toURI()));
+
+        String description =
+            Messages.format(
+                RefactoringCoreMessages.MoveCompilationUnitChange_name,
+                new String[] {BasicElementLabels.getFileName(unit), packageChange.getNewName()});
+        cuResourceChange.setDescription(description);
+
         edit.getCheResourceChanges().add(cuResourceChange);
       }
     }
@@ -177,6 +230,7 @@ public class ChangeUtil {
     rc.setCurrent(ResourceUtils.fixURI(modifiedCU.getResource().getRawLocationURI()));
     IPath newPath = currentPath.removeLastSegments(1).append(newCUName);
     rc.setNewUri(ResourceUtils.fixURI(newPath.toFile().toURI()));
+    rc.setDescription(cuChange.getName());
     edit.getCheResourceChanges().add(rc);
   }
 

--- a/org-eclipse-che-jdt-ls-extension/jdt.ls.extension.core/src/main/java/org/eclipse/che/jdt/ls/extension/core/internal/CheDelegateCommandHandler.java
+++ b/org-eclipse-che-jdt-ls-extension/jdt.ls.extension.core/src/main/java/org/eclipse/che/jdt/ls/extension/core/internal/CheDelegateCommandHandler.java
@@ -34,6 +34,10 @@ import org.eclipse.che.jdt.ls.extension.core.internal.pom.EffectivePomHandler;
 import org.eclipse.che.jdt.ls.extension.core.internal.pom.GetMavenProjectsCommand;
 import org.eclipse.che.jdt.ls.extension.core.internal.pom.ReImportMavenProjectsHandler;
 import org.eclipse.che.jdt.ls.extension.core.internal.pom.RecomputePomDiagnosticsCommand;
+import org.eclipse.che.jdt.ls.extension.core.internal.refactoring.move.GetDestinationsCommand;
+import org.eclipse.che.jdt.ls.extension.core.internal.refactoring.move.MoveCommand;
+import org.eclipse.che.jdt.ls.extension.core.internal.refactoring.move.ValidateMoveCommand;
+import org.eclipse.che.jdt.ls.extension.core.internal.refactoring.move.VerifyMoveDestinationCommand;
 import org.eclipse.che.jdt.ls.extension.core.internal.refactoring.rename.GetLinkedElementsCommand;
 import org.eclipse.che.jdt.ls.extension.core.internal.refactoring.rename.GetRenamingElementInfoCommand;
 import org.eclipse.che.jdt.ls.extension.core.internal.refactoring.rename.RenameCommand;
@@ -94,6 +98,10 @@ public class CheDelegateCommandHandler implements IDelegateCommandHandler {
     commands.put(Commands.GET_RENAME_TYPE_COMMAND, GetRenamingElementInfoCommand::execute);
     commands.put(Commands.VALIDATE_RENAMED_NAME_COMMAND, ValidateNewNameCommand::execute);
     commands.put(Commands.GET_LINKED_ELEMENTS_COMMAND, GetLinkedElementsCommand::execute);
+    commands.put(Commands.GET_DESTINATIONS_COMMAND, GetDestinationsCommand::execute);
+    commands.put(Commands.MOVE_COMMAND, MoveCommand::execute);
+    commands.put(Commands.VALIDATE_MOVE_COMMAND, ValidateMoveCommand::execute);
+    commands.put(Commands.VERIFY_MOVE_DESTINATION_COMMAND, VerifyMoveDestinationCommand::execute);
   }
 
   @Override

--- a/org-eclipse-che-jdt-ls-extension/jdt.ls.extension.core/src/main/java/org/eclipse/che/jdt/ls/extension/core/internal/refactoring/move/GetDestinationsCommand.java
+++ b/org-eclipse-che-jdt-ls-extension/jdt.ls.extension.core/src/main/java/org/eclipse/che/jdt/ls/extension/core/internal/refactoring/move/GetDestinationsCommand.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.jdt.ls.extension.core.internal.refactoring.move;
+
+import static org.eclipse.che.jdt.ls.extension.core.internal.Utils.ensureNotCancelled;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.eclipse.che.jdt.ls.extension.api.dto.JavaProjectStructure;
+import org.eclipse.che.jdt.ls.extension.api.dto.PackageFragment;
+import org.eclipse.che.jdt.ls.extension.api.dto.PackageFragmentRoot;
+import org.eclipse.che.jdt.ls.extension.core.internal.JavaModelUtil;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.jdt.core.IJavaElement;
+import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.core.IPackageFragment;
+import org.eclipse.jdt.core.IPackageFragmentRoot;
+import org.eclipse.jdt.ls.core.internal.JDTUtils;
+import org.eclipse.jdt.ls.core.internal.JavaLanguageServerPlugin;
+
+/**
+ * The command to get all available destinations.
+ *
+ * @author Valeriy Svydenko
+ */
+public class GetDestinationsCommand {
+  /**
+   * Find all possible destinations.
+   *
+   * @return list of the destinations
+   */
+  public static List<JavaProjectStructure> execute(List<Object> arguments, IProgressMonitor pm) {
+    ensureNotCancelled(pm);
+
+    List<IJavaProject> workspaceJavaProjects = JavaModelUtil.getWorkspaceJavaProjects();
+    List<JavaProjectStructure> result = new ArrayList<>();
+    for (IJavaProject javaProject : workspaceJavaProjects) {
+      if (javaProject.exists()) {
+        JavaProjectStructure project = new JavaProjectStructure();
+        String projectUri = JDTUtils.getFileURI(javaProject.getResource());
+        project.setName(projectUri.substring(projectUri.lastIndexOf(JDTUtils.PATH_SEPARATOR) + 1));
+        project.setUri(projectUri);
+        try {
+          project.setPackageRoots(toPackageRoots(javaProject, projectUri));
+        } catch (CoreException e) {
+          JavaLanguageServerPlugin.logException(e.getMessage(), e);
+        }
+        result.add(project);
+      }
+    }
+    return result;
+  }
+
+  private static List<PackageFragmentRoot> toPackageRoots(
+      IJavaProject javaProject, String projectUri) throws CoreException {
+    IPackageFragmentRoot[] packageFragmentRoots = javaProject.getAllPackageFragmentRoots();
+    List<PackageFragmentRoot> result = new ArrayList<>();
+    for (IPackageFragmentRoot packageFragmentRoot : packageFragmentRoots) {
+      if (packageFragmentRoot.getKind() == IPackageFragmentRoot.K_SOURCE
+          && javaProject.getPath().isPrefixOf(packageFragmentRoot.getPath())) {
+        PackageFragmentRoot root = new PackageFragmentRoot();
+        root.setUri(JDTUtils.getFileURI(packageFragmentRoot.getResource()));
+        root.setProjectUri(projectUri);
+        root.setPackages(toPackageFragments(packageFragmentRoot, projectUri));
+        result.add(root);
+      }
+    }
+    return result;
+  }
+
+  private static List<PackageFragment> toPackageFragments(
+      IPackageFragmentRoot packageFragmentRoot, String projectUri) throws CoreException {
+    IJavaElement[] children = packageFragmentRoot.getChildren();
+    if (children == null) {
+      return null;
+    }
+    List<PackageFragment> result = new ArrayList<>();
+    for (IJavaElement child : children) {
+      if (child instanceof IPackageFragment) {
+        IPackageFragment packageFragment = (IPackageFragment) child;
+        PackageFragment fragment = new PackageFragment();
+        fragment.setName(packageFragment.getElementName());
+        fragment.setUri(JDTUtils.getFileURI(packageFragment.getResource()));
+        fragment.setProjectUri(projectUri);
+        result.add(fragment);
+      }
+    }
+    return result;
+  }
+}

--- a/org-eclipse-che-jdt-ls-extension/jdt.ls.extension.core/src/main/java/org/eclipse/che/jdt/ls/extension/core/internal/refactoring/move/MoveCommand.java
+++ b/org-eclipse-che-jdt-ls-extension/jdt.ls.extension.core/src/main/java/org/eclipse/che/jdt/ls/extension/core/internal/refactoring/move/MoveCommand.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.jdt.ls.extension.core.internal.refactoring.move;
+
+import static org.eclipse.che.jdt.ls.extension.core.internal.Utils.ensureNotCancelled;
+
+import com.google.common.base.Preconditions;
+import com.google.gson.Gson;
+import java.net.URI;
+import java.util.LinkedList;
+import java.util.List;
+import org.eclipse.che.jdt.ls.extension.api.dto.CheWorkspaceEdit;
+import org.eclipse.che.jdt.ls.extension.api.dto.MoveSettings;
+import org.eclipse.che.jdt.ls.extension.api.dto.Resource;
+import org.eclipse.che.jdt.ls.extension.core.internal.ChangeUtil;
+import org.eclipse.che.jdt.ls.extension.core.internal.GsonUtils;
+import org.eclipse.core.resources.IFolder;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.resources.ResourcesPlugin;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.IJavaElement;
+import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.core.IPackageFragment;
+import org.eclipse.jdt.core.JavaCore;
+import org.eclipse.jdt.core.JavaModelException;
+import org.eclipse.jdt.ls.core.internal.JDTUtils;
+import org.eclipse.jdt.ls.core.internal.JavaLanguageServerPlugin;
+import org.eclipse.jdt.ls.core.internal.ProjectUtils;
+import org.eclipse.jdt.ls.core.internal.corext.refactoring.reorg.IReorgDestination;
+import org.eclipse.jdt.ls.core.internal.corext.refactoring.reorg.IReorgPolicy.IMovePolicy;
+import org.eclipse.jdt.ls.core.internal.corext.refactoring.reorg.JavaMoveProcessor;
+import org.eclipse.jdt.ls.core.internal.corext.refactoring.reorg.ReorgDestinationFactory;
+import org.eclipse.jdt.ls.core.internal.corext.refactoring.reorg.ReorgPolicyFactory;
+import org.eclipse.ltk.core.refactoring.Change;
+
+/**
+ * The command to perform move.
+ *
+ * @author Valeriy Svydenko
+ */
+public class MoveCommand {
+  private static final Gson GSON = GsonUtils.getInstance();
+
+  /**
+   * The command executes Move refactoring.
+   *
+   * @param arguments {@link MoveSettings} expected
+   * @return information about changes
+   */
+  public static CheWorkspaceEdit execute(List<Object> arguments, IProgressMonitor pm) {
+    validateArguments(arguments);
+
+    ensureNotCancelled(pm);
+
+    CheWorkspaceEdit edit = new CheWorkspaceEdit();
+
+    MoveSettings moveSettings = GSON.fromJson(GSON.toJson(arguments.get(0)), MoveSettings.class);
+
+    String destinationUri = moveSettings.getDestination();
+    if (destinationUri == null || destinationUri.isEmpty()) {
+      return edit;
+    }
+
+    List<IJavaElement> elements = convertToJavaElements(moveSettings.getElements());
+    IJavaElement[] javaElements = new IJavaElement[elements.size()];
+    javaElements = elements.toArray(javaElements);
+    ;
+    IResource[] resources = {};
+
+    try {
+      IMovePolicy policy = ReorgPolicyFactory.createMovePolicy(resources, javaElements);
+      JavaMoveProcessor processor = policy.canEnable() ? new JavaMoveProcessor(policy) : null;
+      if (processor == null) {
+        return edit;
+      }
+
+      IPackageFragment resolvePackage = getDestination(JDTUtils.toURI(destinationUri));
+      if (resolvePackage == null) {
+        return edit;
+      }
+
+      IReorgDestination destination = ReorgDestinationFactory.createDestination(resolvePackage);
+      org.eclipse.ltk.core.refactoring.RefactoringStatus status =
+          processor.setDestination(destination);
+
+      if (status == null || !status.isOK()) {
+        return edit;
+      }
+
+      setMoveSettings(processor, moveSettings);
+
+      Change changes = processor.createChange(pm);
+      if (changes == null) {
+        return edit;
+      }
+
+      ChangeUtil.convertChanges(changes, edit);
+
+    } catch (CoreException e) {
+      JavaLanguageServerPlugin.logException(e.getMessage(), e);
+    }
+    return edit;
+  }
+
+  private static IPackageFragment getDestination(URI destinationUri) throws JavaModelException {
+    IFolder resource =
+        (IFolder)
+            JDTUtils.findResource(
+                destinationUri,
+                ResourcesPlugin.getWorkspace().getRoot()::findContainersForLocationURI);
+    if (resource == null) {
+      return null;
+    }
+    IProject project = resource.getProject();
+    if (!ProjectUtils.isJavaProject(project)) {
+      return null;
+    }
+    IJavaElement element = JavaCore.create(resource);
+    IJavaProject javaProject = element.getJavaProject();
+    return javaProject.findPackageFragment(element.getPath());
+  }
+
+  private static void setMoveSettings(JavaMoveProcessor processor, MoveSettings moveSettings) {
+    processor.setUpdateReferences(moveSettings.isUpdateReferences());
+    boolean updateQualifiedNames = moveSettings.isUpdateQualifiedNames();
+    processor.setUpdateQualifiedNames(updateQualifiedNames);
+    String filePatterns = moveSettings.getFilePatterns();
+    if (updateQualifiedNames && filePatterns != null) {
+      processor.setFilePatterns(filePatterns);
+    }
+  }
+
+  private static List<IJavaElement> convertToJavaElements(List<Resource> resources) {
+    List<IJavaElement> result = new LinkedList();
+    for (Resource resourceToMove : resources) {
+      if (resourceToMove.isPack()) {
+        IPackageFragment pack = JDTUtils.resolvePackage(resourceToMove.getUri());
+        if (pack != null) {
+          result.add(pack);
+        }
+      } else {
+        ICompilationUnit unit = JDTUtils.resolveCompilationUnit(resourceToMove.getUri());
+        if (unit != null) {
+          result.add(unit);
+        }
+      }
+    }
+    return result;
+  }
+
+  private static void validateArguments(List<Object> arguments) {
+    Preconditions.checkArgument(
+        !arguments.isEmpty(), MoveCommand.class.getName() + " is expected.");
+  }
+}

--- a/org-eclipse-che-jdt-ls-extension/jdt.ls.extension.core/src/main/java/org/eclipse/che/jdt/ls/extension/core/internal/refactoring/move/ValidateMoveCommand.java
+++ b/org-eclipse-che-jdt-ls-extension/jdt.ls.extension.core/src/main/java/org/eclipse/che/jdt/ls/extension/core/internal/refactoring/move/ValidateMoveCommand.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.jdt.ls.extension.core.internal.refactoring.move;
+
+import static org.eclipse.che.jdt.ls.extension.core.internal.Utils.ensureNotCancelled;
+
+import com.google.common.base.Preconditions;
+import com.google.gson.Gson;
+import java.util.List;
+import java.util.function.Function;
+import org.eclipse.che.jdt.ls.extension.api.dto.CreateMoveParams;
+import org.eclipse.che.jdt.ls.extension.api.dto.Resource;
+import org.eclipse.che.jdt.ls.extension.core.internal.GsonUtils;
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.jdt.core.IJavaElement;
+import org.eclipse.jdt.core.JavaModelException;
+import org.eclipse.jdt.ls.core.internal.JDTUtils;
+import org.eclipse.jdt.ls.core.internal.JavaLanguageServerPlugin;
+import org.eclipse.jdt.ls.core.internal.corext.refactoring.RefactoringAvailabilityTester;
+
+/**
+ * The command to check availability of Move operation.
+ *
+ * @author Valeriy Svydenko
+ */
+public class ValidateMoveCommand {
+  private static final Gson GSON = GsonUtils.getInstance();
+
+  /**
+   * The command checks if it's possible to execute Move refactoring.
+   *
+   * @param arguments list of {@link Resource} expected
+   * @return true if operation is available otherwise - false
+   */
+  public static boolean execute(List<Object> arguments, IProgressMonitor pm) {
+    validateArguments(arguments);
+    ensureNotCancelled(pm);
+
+    CreateMoveParams moveParams =
+        GSON.fromJson(GSON.toJson(arguments.get(0)), CreateMoveParams.class);
+
+    Function<Resource, IJavaElement> mapper =
+        resource -> {
+          if (resource.isPack()) {
+            return JDTUtils.resolvePackage(resource.getUri());
+          } else {
+            return JDTUtils.resolveCompilationUnit(resource.getUri());
+          }
+        };
+    IJavaElement[] javaElements =
+        moveParams.getResources().stream().map(mapper).toArray(IJavaElement[]::new);
+
+    try {
+      return RefactoringAvailabilityTester.isMoveAvailable(new IResource[0], javaElements);
+    } catch (JavaModelException e) {
+      JavaLanguageServerPlugin.logException(e.getMessage(), e);
+      return false;
+    }
+  }
+
+  private static void validateArguments(List<Object> arguments) {
+    Preconditions.checkArgument(
+        !arguments.isEmpty(), ValidateMoveCommand.class.getName() + " is expected.");
+  }
+}

--- a/org-eclipse-che-jdt-ls-extension/jdt.ls.extension.core/src/main/java/org/eclipse/che/jdt/ls/extension/core/internal/refactoring/move/VerifyMoveDestinationCommand.java
+++ b/org-eclipse-che-jdt-ls-extension/jdt.ls.extension.core/src/main/java/org/eclipse/che/jdt/ls/extension/core/internal/refactoring/move/VerifyMoveDestinationCommand.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.jdt.ls.extension.core.internal.refactoring.move;
+
+import static org.eclipse.che.jdt.ls.extension.core.internal.Utils.ensureNotCancelled;
+
+import com.google.common.base.Preconditions;
+import com.google.gson.Gson;
+import java.net.URI;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+import org.eclipse.che.jdt.ls.extension.api.RefactoringSeverity;
+import org.eclipse.che.jdt.ls.extension.api.dto.MoveSettings;
+import org.eclipse.che.jdt.ls.extension.api.dto.RefactoringStatus;
+import org.eclipse.che.jdt.ls.extension.api.dto.RefactoringStatusEntry;
+import org.eclipse.che.jdt.ls.extension.api.dto.Resource;
+import org.eclipse.che.jdt.ls.extension.core.internal.GsonUtils;
+import org.eclipse.core.resources.IFolder;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.resources.ResourcesPlugin;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.IJavaElement;
+import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.core.IPackageFragment;
+import org.eclipse.jdt.core.JavaCore;
+import org.eclipse.jdt.core.JavaModelException;
+import org.eclipse.jdt.ls.core.internal.JDTUtils;
+import org.eclipse.jdt.ls.core.internal.JavaLanguageServerPlugin;
+import org.eclipse.jdt.ls.core.internal.ProjectUtils;
+import org.eclipse.jdt.ls.core.internal.corext.refactoring.reorg.IReorgDestination;
+import org.eclipse.jdt.ls.core.internal.corext.refactoring.reorg.IReorgPolicy.IMovePolicy;
+import org.eclipse.jdt.ls.core.internal.corext.refactoring.reorg.JavaMoveProcessor;
+import org.eclipse.jdt.ls.core.internal.corext.refactoring.reorg.ReorgDestinationFactory;
+import org.eclipse.jdt.ls.core.internal.corext.refactoring.reorg.ReorgPolicyFactory;
+
+/**
+ * The command to check destination.
+ *
+ * @author Valeriy Svydenko
+ */
+public class VerifyMoveDestinationCommand {
+  private static final Gson GSON = GsonUtils.getInstance();
+
+  /**
+   * The command checks if destination is available.
+   *
+   * @param arguments instance of {@link MoveSettings}
+   * @return status of the move operation {@link RefactoringStatus}
+   */
+  public static RefactoringStatus execute(List<Object> arguments, IProgressMonitor pm) {
+    validateArguments(arguments);
+    ensureNotCancelled(pm);
+
+    MoveSettings moveSettings = GSON.fromJson(GSON.toJson(arguments.get(0)), MoveSettings.class);
+    String destinationUri = moveSettings.getDestination();
+
+    if (destinationUri == null || destinationUri.isEmpty()) {
+      return createBadStatus("URI of the destination hs to be set.");
+    }
+
+    List<IJavaElement> elements = convertToJavaElements(moveSettings.getElements());
+    IJavaElement[] javaElements = new IJavaElement[elements.size()];
+    javaElements = elements.toArray(javaElements);
+
+    IResource[] resources = {};
+    RefactoringStatus result = new RefactoringStatus();
+
+    try {
+      IMovePolicy policy = ReorgPolicyFactory.createMovePolicy(resources, javaElements);
+      JavaMoveProcessor processor = policy.canEnable() ? new JavaMoveProcessor(policy) : null;
+      if (processor == null) {
+        return createBadStatus("Can't create move processor");
+      }
+
+      IPackageFragment resolvePackage = getDestination(JDTUtils.toURI(destinationUri));
+      if (resolvePackage == null) {
+        return createBadStatus("The destination can't be used.");
+      }
+
+      IReorgDestination destination = ReorgDestinationFactory.createDestination(resolvePackage);
+      org.eclipse.ltk.core.refactoring.RefactoringStatus status =
+          processor.setDestination(destination);
+
+      if (status == null) {
+        return createBadStatus("Can't validate destination.");
+      }
+      result.setRefactoringSeverity(RefactoringSeverity.valueOf(status.getSeverity()));
+      List<RefactoringStatusEntry> entries = new LinkedList<>();
+      for (org.eclipse.ltk.core.refactoring.RefactoringStatusEntry entry : status.getEntries()) {
+        RefactoringStatusEntry resultEntry = new RefactoringStatusEntry();
+        resultEntry.setMessage(entry.getMessage());
+        resultEntry.setRefactoringSeverity(RefactoringSeverity.valueOf(entry.getSeverity()));
+        entries.add(resultEntry);
+      }
+      result.setRefactoringStatusEntries(entries);
+    } catch (CoreException e) {
+      JavaLanguageServerPlugin.logException(e.getMessage(), e);
+    }
+    return result;
+  }
+
+  private static IPackageFragment getDestination(URI destinationUri) throws JavaModelException {
+    IFolder resource =
+        (IFolder)
+            JDTUtils.findResource(
+                destinationUri,
+                ResourcesPlugin.getWorkspace().getRoot()::findContainersForLocationURI);
+    if (resource == null) {
+      return null;
+    }
+    IProject project = resource.getProject();
+    if (!ProjectUtils.isJavaProject(project)) {
+      return null;
+    }
+    IJavaElement element = JavaCore.create(resource);
+    IJavaProject javaProject = element.getJavaProject();
+    return javaProject.findPackageFragment(element.getPath());
+  }
+
+  private static RefactoringStatus createBadStatus(String message) {
+    RefactoringStatus status = new RefactoringStatus();
+    status.setRefactoringSeverity(RefactoringSeverity.FATAL);
+    RefactoringStatusEntry entry = new RefactoringStatusEntry();
+    entry.setRefactoringSeverity(RefactoringSeverity.FATAL);
+    entry.setMessage(message);
+    status.setRefactoringStatusEntries(Collections.singletonList(entry));
+
+    return status;
+  }
+
+  private static List<IJavaElement> convertToJavaElements(List<Resource> resources) {
+    List<IJavaElement> result = new LinkedList();
+    for (Resource resourceToMove : resources) {
+      if (resourceToMove.isPack()) {
+        IPackageFragment pack = JDTUtils.resolvePackage(resourceToMove.getUri());
+        if (pack != null) {
+          result.add(pack);
+        }
+      } else {
+        ICompilationUnit unit = JDTUtils.resolveCompilationUnit(resourceToMove.getUri());
+        if (unit != null) {
+          result.add(unit);
+        }
+      }
+    }
+    return result;
+  }
+
+  private static void validateArguments(List<Object> arguments) {
+    Preconditions.checkArgument(
+        !arguments.isEmpty(), VerifyMoveDestinationCommand.class.getName() + " is expected.");
+  }
+}

--- a/org-eclipse-che-jdt-ls-extension/jdt.ls.extension.core/src/main/java/org/eclipse/che/jdt/ls/extension/core/internal/refactoring/rename/RenameCommand.java
+++ b/org-eclipse-che-jdt-ls-extension/jdt.ls.extension.core/src/main/java/org/eclipse/che/jdt/ls/extension/core/internal/refactoring/rename/RenameCommand.java
@@ -18,6 +18,7 @@ import java.util.List;
 import org.eclipse.che.jdt.ls.extension.api.RenameKind;
 import org.eclipse.che.jdt.ls.extension.api.dto.CheWorkspaceEdit;
 import org.eclipse.che.jdt.ls.extension.api.dto.RenameSettings;
+import org.eclipse.che.jdt.ls.extension.core.internal.ChangeUtil;
 import org.eclipse.che.jdt.ls.extension.core.internal.GsonUtils;
 import org.eclipse.che.jdt.ls.extension.core.internal.JavaModelUtil;
 import org.eclipse.core.runtime.CoreException;

--- a/org-eclipse-che-jdt-ls-extension/jdt.ls.extension.core/src/main/java/org/eclipse/che/jdt/ls/extension/core/internal/refactoring/rename/ValidateNewNameCommand.java
+++ b/org-eclipse-che-jdt-ls-extension/jdt.ls.extension.core/src/main/java/org/eclipse/che/jdt/ls/extension/core/internal/refactoring/rename/ValidateNewNameCommand.java
@@ -18,7 +18,7 @@ import java.util.ArrayList;
 import java.util.List;
 import org.eclipse.che.jdt.ls.extension.api.RefactoringSeverity;
 import org.eclipse.che.jdt.ls.extension.api.RenameKind;
-import org.eclipse.che.jdt.ls.extension.api.dto.NameValidationStatus;
+import org.eclipse.che.jdt.ls.extension.api.dto.RefactoringStatus;
 import org.eclipse.che.jdt.ls.extension.api.dto.RefactoringStatusEntry;
 import org.eclipse.che.jdt.ls.extension.api.dto.RenameSelectionParams;
 import org.eclipse.che.jdt.ls.extension.core.internal.GsonUtils;
@@ -31,7 +31,6 @@ import org.eclipse.jdt.ls.core.internal.JavaLanguageServerPlugin;
 import org.eclipse.jdt.ls.core.internal.corext.refactoring.rename.JavaRenameProcessor;
 import org.eclipse.jdt.ls.core.internal.corext.refactoring.rename.RenameSupport;
 import org.eclipse.lsp4j.Position;
-import org.eclipse.ltk.core.refactoring.RefactoringStatus;
 
 /**
  * The command to validate new name.
@@ -48,14 +47,14 @@ public class ValidateNewNameCommand {
    * @param pm progress monitor
    * @return satus of validation
    */
-  public static NameValidationStatus execute(List<Object> arguments, IProgressMonitor pm) {
+  public static RefactoringStatus execute(List<Object> arguments, IProgressMonitor pm) {
     validateArguments(arguments);
     ensureNotCancelled(pm);
 
     RenameSelectionParams params =
         GSON.fromJson(GSON.toJson(arguments.get(0)), RenameSelectionParams.class);
 
-    NameValidationStatus status = new NameValidationStatus();
+    RefactoringStatus status = new RefactoringStatus();
 
     try {
       RenameKind renameType = params.getRenameKind();
@@ -83,7 +82,8 @@ public class ValidateNewNameCommand {
       RenameSupport renameSupport =
           RenameSupport.create(curr, params.getNewName(), RenameSupport.UPDATE_REFERENCES);
       JavaRenameProcessor processor = renameSupport.getJavaRenameProcessor();
-      RefactoringStatus result = processor.checkNewElementName(params.getNewName());
+      org.eclipse.ltk.core.refactoring.RefactoringStatus result =
+          processor.checkNewElementName(params.getNewName());
 
       status.setRefactoringSeverity(RefactoringSeverity.valueOf(result.getSeverity()));
 


### PR DESCRIPTION
Signed-off-by: Valeriy Svydenko <vsvydenk@redhat.com>

Adds a set of commands to support Move refactoring:

Check if Move is possible;
Provides all destinations;
Validate selected destination;
Call Move operation.

This PR depends on: https://github.com/eclipse/eclipse.jdt.ls/pull/683