### PR TITLE
Add status of the refactoring operation after preparing changes

### DIFF
--- a/org-eclipse-che-jdt-ls-extension/jdt.ls.extension.api/src/main/java/org/eclipse/che/jdt/ls/extension/api/dto/RefactoringResult.java
+++ b/org-eclipse-che-jdt-ls-extension/jdt.ls.extension.api/src/main/java/org/eclipse/che/jdt/ls/extension/api/dto/RefactoringResult.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.jdt.ls.extension.api.dto;
+
+/**
+ * Describes the information about preparing changes for refactoring operation.
+ *
+ * @author Valeriy Svydenko
+ */
+public class RefactoringResult {
+  private RefactoringStatus refactoringStatus;
+  private CheWorkspaceEdit cheWorkspaceEdit;
+
+  /** Returns the status of the refactoring operation see {@link RefactoringStatus} */
+  public RefactoringStatus getRefactoringStatus() {
+    return refactoringStatus;
+  }
+
+  public void setRefactoringStatus(RefactoringStatus refactoringStatus) {
+    this.refactoringStatus = refactoringStatus;
+  }
+
+  /** Returns instance of {@link CheWorkspaceEdit} with all changes. */
+  public CheWorkspaceEdit getCheWorkspaceEdit() {
+    return cheWorkspaceEdit;
+  }
+
+  public void setCheWorkspaceEdit(CheWorkspaceEdit cheWorkspaceEdit) {
+    this.cheWorkspaceEdit = cheWorkspaceEdit;
+  }
+}

--- a/org-eclipse-che-jdt-ls-extension/jdt.ls.extension.core/src/main/java/org/eclipse/che/jdt/ls/extension/core/internal/ChangeUtil.java
+++ b/org-eclipse-che-jdt-ls-extension/jdt.ls.extension.core/src/main/java/org/eclipse/che/jdt/ls/extension/core/internal/ChangeUtil.java
@@ -14,9 +14,11 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import org.eclipse.che.jdt.ls.extension.api.RefactoringSeverity;
 import org.eclipse.che.jdt.ls.extension.api.ResourceKind;
 import org.eclipse.che.jdt.ls.extension.api.dto.CheResourceChange;
 import org.eclipse.che.jdt.ls.extension.api.dto.CheWorkspaceEdit;
+import org.eclipse.che.jdt.ls.extension.api.dto.RefactoringStatusEntry;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.Path;
@@ -51,6 +53,7 @@ import org.eclipse.jdt.ls.core.internal.corext.refactoring.util.RefactoringASTPa
 import org.eclipse.jdt.ls.core.internal.corext.util.JavaElementUtil;
 import org.eclipse.ltk.core.refactoring.Change;
 import org.eclipse.ltk.core.refactoring.CompositeChange;
+import org.eclipse.ltk.core.refactoring.RefactoringStatus;
 import org.eclipse.ltk.core.refactoring.TextChange;
 import org.eclipse.ltk.core.refactoring.resource.ResourceChange;
 import org.eclipse.text.edits.TextEdit;
@@ -86,6 +89,31 @@ public class ChangeUtil {
         convertCompositeChange(ch, edit);
       }
     }
+  }
+
+  /**
+   * Converts {@link RefactoringStatus} to dto object {@link
+   * org.eclipse.che.jdt.ls.extension.api.dto.RefactoringStatus}.
+   *
+   * @param status the object to be converted
+   * @return dto object which describes status of the refactoring
+   */
+  public static org.eclipse.che.jdt.ls.extension.api.dto.RefactoringStatus convertRefactoringStatus(
+      RefactoringStatus status) {
+    org.eclipse.che.jdt.ls.extension.api.dto.RefactoringStatus result =
+        new org.eclipse.che.jdt.ls.extension.api.dto.RefactoringStatus();
+    result.setRefactoringSeverity(RefactoringSeverity.valueOf(status.getSeverity()));
+
+    List<RefactoringStatusEntry> entries = new ArrayList<>();
+    for (org.eclipse.ltk.core.refactoring.RefactoringStatusEntry entry : status.getEntries()) {
+      RefactoringStatusEntry newEntry = new RefactoringStatusEntry();
+      newEntry.setMessage(entry.getMessage());
+      newEntry.setRefactoringSeverity(RefactoringSeverity.valueOf(entry.getSeverity()));
+      entries.add(newEntry);
+    }
+
+    result.setRefactoringStatusEntries(entries);
+    return result;
   }
 
   private static void convertCompositeChange(Change change, CheWorkspaceEdit edit)

--- a/org-eclipse-che-jdt-ls-extension/jdt.ls.extension.core/src/main/java/org/eclipse/che/jdt/ls/extension/core/internal/refactoring/rename/ValidateNewNameCommand.java
+++ b/org-eclipse-che-jdt-ls-extension/jdt.ls.extension.core/src/main/java/org/eclipse/che/jdt/ls/extension/core/internal/refactoring/rename/ValidateNewNameCommand.java
@@ -14,13 +14,11 @@ import static org.eclipse.che.jdt.ls.extension.core.internal.Utils.ensureNotCanc
 
 import com.google.common.base.Preconditions;
 import com.google.gson.Gson;
-import java.util.ArrayList;
 import java.util.List;
-import org.eclipse.che.jdt.ls.extension.api.RefactoringSeverity;
 import org.eclipse.che.jdt.ls.extension.api.RenameKind;
 import org.eclipse.che.jdt.ls.extension.api.dto.RefactoringStatus;
-import org.eclipse.che.jdt.ls.extension.api.dto.RefactoringStatusEntry;
 import org.eclipse.che.jdt.ls.extension.api.dto.RenameSelectionParams;
+import org.eclipse.che.jdt.ls.extension.core.internal.ChangeUtil;
 import org.eclipse.che.jdt.ls.extension.core.internal.GsonUtils;
 import org.eclipse.che.jdt.ls.extension.core.internal.JavaModelUtil;
 import org.eclipse.core.runtime.CoreException;
@@ -85,17 +83,7 @@ public class ValidateNewNameCommand {
       org.eclipse.ltk.core.refactoring.RefactoringStatus result =
           processor.checkNewElementName(params.getNewName());
 
-      status.setRefactoringSeverity(RefactoringSeverity.valueOf(result.getSeverity()));
-
-      List<RefactoringStatusEntry> entries = new ArrayList<>();
-      for (org.eclipse.ltk.core.refactoring.RefactoringStatusEntry entry : result.getEntries()) {
-        RefactoringStatusEntry e = new RefactoringStatusEntry();
-        e.setMessage(entry.getMessage());
-        e.setRefactoringSeverity(RefactoringSeverity.valueOf(entry.getSeverity()));
-        entries.add(e);
-      }
-
-      status.setRefactoringStatusEntries(entries);
+      status = ChangeUtil.convertRefactoringStatus(result);
 
     } catch (CoreException ex) {
       JavaLanguageServerPlugin.logException("Can't validate new name: " + params.getNewName(), ex);


### PR DESCRIPTION
Signed-off-by: Valeriy Svydenko <vsvydenk@redhat.com>
The main idea is to return an object which describes status of the refactoring and all changes as a result of doing refactoring operation.

It is needed to fix https://github.com/eclipse/che/issues/10034  