### PR TITLE
Notify client when configuration is changed

### DIFF
--- a/org-eclipse-che-jdt-ls-extension/jdt.ls.extension.api/src/main/java/org/eclipse/che/jdt/ls/extension/api/Commands.java
+++ b/org-eclipse-che-jdt-ls-extension/jdt.ls.extension.api/src/main/java/org/eclipse/che/jdt/ls/extension/api/Commands.java
@@ -109,6 +109,8 @@ public class Commands {
       "che.jdt.ls.extension.workspace.clientUpdateProject";
   public static final String CLIENT_UPDATE_ON_PROJECT_CLASSPATH_CHANGED =
       "che.jdt.ls.extension.workspace.clientUpdateOnProjectClasspathChanged";
+  public static final String CLIENT_UPDATE_PROJECT_CONFIG =
+      "che.jdt.ls.extension.workspace.clientUpdateProjectConfig";
 
   private Commands() {}
 }

--- a/org-eclipse-che-jdt-ls-extension/jdt.ls.extension.core/src/main/java/org/eclipse/che/jdt/ls/extension/core/internal/ExtensionActivator.java
+++ b/org-eclipse-che-jdt-ls-extension/jdt.ls.extension.core/src/main/java/org/eclipse/che/jdt/ls/extension/core/internal/ExtensionActivator.java
@@ -12,6 +12,7 @@
 package org.eclipse.che.jdt.ls.extension.core.internal;
 
 import org.eclipse.jdt.core.JavaCore;
+import org.eclipse.m2e.core.MavenPlugin;
 import org.osgi.framework.BundleActivator;
 import org.osgi.framework.BundleContext;
 
@@ -24,13 +25,18 @@ public class ExtensionActivator implements BundleActivator {
   // The shared instance
   private static ExtensionActivator plugin;
   private static final JavaModelEventProvider javaModelEventProvider = new JavaModelEventProvider();
+  private static final MavenProjectConfigurator mavenProjectConfigurator =
+      new MavenProjectConfigurator();
 
   public void start(BundleContext context) throws Exception {
     plugin = this;
     JavaCore.addElementChangedListener(javaModelEventProvider);
+    MavenPlugin.getMavenProjectRegistry().addMavenProjectChangedListener(mavenProjectConfigurator);
   }
 
   public void stop(BundleContext context) throws Exception {
+    MavenPlugin.getMavenProjectRegistry()
+        .removeMavenProjectChangedListener(mavenProjectConfigurator);
     JavaCore.removeElementChangedListener(javaModelEventProvider);
     plugin = null;
   }

--- a/org-eclipse-che-jdt-ls-extension/jdt.ls.extension.core/src/main/java/org/eclipse/che/jdt/ls/extension/core/internal/MavenProjectConfigurator.java
+++ b/org-eclipse-che-jdt-ls-extension/jdt.ls.extension.core/src/main/java/org/eclipse/che/jdt/ls/extension/core/internal/MavenProjectConfigurator.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.jdt.ls.extension.core.internal;
+
+import org.eclipse.che.jdt.ls.extension.api.Commands;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.jdt.ls.core.internal.JavaLanguageServerPlugin;
+import org.eclipse.jdt.ls.core.internal.ResourceUtils;
+import org.eclipse.jdt.ls.core.internal.handlers.JDTLanguageServer;
+import org.eclipse.m2e.core.project.IMavenProjectChangedListener;
+import org.eclipse.m2e.core.project.IMavenProjectFacade;
+import org.eclipse.m2e.core.project.MavenProjectChangedEvent;
+
+/**
+ * Listens to project configuration changes and notify client if it happened.
+ *
+ * @author tolusha
+ */
+public class MavenProjectConfigurator implements IMavenProjectChangedListener {
+
+  public void mavenProjectChanged(MavenProjectChangedEvent[] events, IProgressMonitor monitor) {
+    for (int i = 0; i < events.length; i++) {
+      mavenProjectChanged(events[i]);
+    }
+  }
+
+  private void mavenProjectChanged(MavenProjectChangedEvent event) {
+    if (isConfigurationUpdated(event.getMavenProject(), event.getOldMavenProject())) {
+      String projectUri = getNormalizedProjectPath(event.getMavenProject());
+      notifyClient(projectUri);
+    }
+  }
+
+  private boolean isConfigurationUpdated(
+      IMavenProjectFacade mavenProject, IMavenProjectFacade oldMavenProject) {
+    return mavenProject != null
+        && oldMavenProject != null
+        && !mavenProject
+            .getArtifactKey()
+            .getArtifactId()
+            .equals(oldMavenProject.getArtifactKey().getArtifactId());
+  }
+
+  private void notifyClient(String projectUri) {
+    try {
+      JDTLanguageServer ls = JavaLanguageServerPlugin.getInstance().getProtocol();
+      ls.getClientConnection()
+          .executeClientCommand(Commands.CLIENT_UPDATE_PROJECT_CONFIG, projectUri);
+    } catch (Exception e) {
+      JavaLanguageServerPlugin.logException(
+          "An exception occurred while reporting project updating", e);
+    }
+  }
+
+  private String getNormalizedProjectPath(IMavenProjectFacade project) {
+    String projectUri = ResourceUtils.fixURI(project.getMavenProject().getBasedir().toURI());
+    if (projectUri.endsWith("/")) {
+      return projectUri.substring(0, projectUri.length() - 1);
+    }
+
+    return projectUri;
+  }
+}


### PR DESCRIPTION
### What does this PR do
When maven configuration is changed it is necessary to notify client to reread configuration and to update the project.