### PR TITLE
Use notifications instead of client commands

### DIFF
--- a/org-eclipse-che-jdt-ls-extension/jdt.ls.extension.api/src/main/java/org/eclipse/che/jdt/ls/extension/api/Commands.java
+++ b/org-eclipse-che-jdt-ls-extension/jdt.ls.extension.api/src/main/java/org/eclipse/che/jdt/ls/extension/api/Commands.java
@@ -100,19 +100,5 @@ public class Commands {
   public static final String VERIFY_MOVE_DESTINATION_COMMAND =
       "che.jdt.ls.extension.refactoring.move.verify.destination";
 
-  // CLASSPATH updater
-  public static final String CLIENT_UPDATE_PROJECTS_CLASSPATH =
-      "che.jdt.ls.extension.workspace.clientUpdateProjectsClasspath";
-
-  // Project updater
-  public static final String CLIENT_UPDATE_PROJECT =
-      "che.jdt.ls.extension.workspace.clientUpdateProject";
-  public static final String CLIENT_UPDATE_ON_PROJECT_CLASSPATH_CHANGED =
-      "che.jdt.ls.extension.workspace.clientUpdateOnProjectClasspathChanged";
-  public static final String CLIENT_UPDATE_MAVEN_MODULE =
-      "che.jdt.ls.extension.workspace.clientUpdateMavenModule";
-  public static final String CLIENT_UPDATE_PROJECT_CONFIG =
-      "che.jdt.ls.extension.workspace.clientUpdateProjectConfig";
-
   private Commands() {}
 }

--- a/org-eclipse-che-jdt-ls-extension/jdt.ls.extension.api/src/main/java/org/eclipse/che/jdt/ls/extension/api/Notifications.java
+++ b/org-eclipse-che-jdt-ls-extension/jdt.ls.extension.api/src/main/java/org/eclipse/che/jdt/ls/extension/api/Notifications.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.jdt.ls.extension.api;
+
+/**
+ * Defines constants related to custom notifications
+ *
+ * @author Thomas Mäder
+ */
+public class Notifications {
+
+  // CLASSPATH updater
+  public static final String UPDATE_PROJECTS_CLASSPATH =
+      "che.jdt.ls.extension.workspace.clientUpdateProjectsClasspath";
+  // Project updater
+  public static final String UPDATE_PROJECT = "che.jdt.ls.extension.workspace.clientUpdateProject";
+  public static final String UPDATE_ON_PROJECT_CLASSPATH_CHANGED =
+      "che.jdt.ls.extension.workspace.clientUpdateOnProjectClasspathChanged";
+  public static final String UPDATE_MAVEN_MODULE =
+      "che.jdt.ls.extension.workspace.clientUpdateMavenModule";
+  public static final String UPDATE_PROJECT_CONFIG =
+      "che.jdt.ls.extension.workspace.clientUpdateProjectConfig";
+}

--- a/org-eclipse-che-jdt-ls-extension/jdt.ls.extension.core/src/main/java/org/eclipse/che/jdt/ls/extension/core/internal/JavaModelEventProvider.java
+++ b/org-eclipse-che-jdt-ls-extension/jdt.ls.extension.core/src/main/java/org/eclipse/che/jdt/ls/extension/core/internal/JavaModelEventProvider.java
@@ -11,7 +11,6 @@
  */
 package org.eclipse.che.jdt.ls.extension.core.internal;
 
-import static org.eclipse.che.jdt.ls.extension.api.Commands.CLIENT_UPDATE_PROJECTS_CLASSPATH;
 import static org.eclipse.jdt.core.IJavaElementDelta.F_ADDED_TO_CLASSPATH;
 import static org.eclipse.jdt.core.IJavaElementDelta.F_ARCHIVE_CONTENT_CHANGED;
 import static org.eclipse.jdt.core.IJavaElementDelta.F_CLASSPATH_CHANGED;
@@ -21,6 +20,7 @@ import static org.eclipse.jdt.core.IJavaElementDelta.F_RESOLVED_CLASSPATH_CHANGE
 
 import java.util.HashSet;
 import java.util.Set;
+import org.eclipse.che.jdt.ls.extension.api.Notifications;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.jdt.core.ElementChangedEvent;
 import org.eclipse.jdt.core.IElementChangedListener;
@@ -63,8 +63,8 @@ public class JavaModelEventProvider implements IElementChangedListener {
 
       JDTLanguageServer ls = JavaLanguageServerPlugin.getInstance().getProtocol();
       ls.getClientConnection()
-          .executeClientCommand(
-              CLIENT_UPDATE_PROJECTS_CLASSPATH,
+          .sendNotification(
+              Notifications.UPDATE_PROJECTS_CLASSPATH,
               (Object[]) projectLocations.toArray(new String[projectLocations.size()]));
     } catch (Exception e) {
       // Ignore.

--- a/org-eclipse-che-jdt-ls-extension/jdt.ls.extension.core/src/main/java/org/eclipse/che/jdt/ls/extension/core/internal/MavenProjectConfigurator.java
+++ b/org-eclipse-che-jdt-ls-extension/jdt.ls.extension.core/src/main/java/org/eclipse/che/jdt/ls/extension/core/internal/MavenProjectConfigurator.java
@@ -13,7 +13,7 @@ package org.eclipse.che.jdt.ls.extension.core.internal;
 
 import java.util.ArrayList;
 import java.util.List;
-import org.eclipse.che.jdt.ls.extension.api.Commands;
+import org.eclipse.che.jdt.ls.extension.api.Notifications;
 import org.eclipse.che.jdt.ls.extension.api.dto.UpdateMavenModulesInfo;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.jdt.ls.core.internal.JavaLanguageServerPlugin;
@@ -45,7 +45,7 @@ public class MavenProjectConfigurator implements IMavenProjectChangedListener {
     }
     if (isConfigurationUpdated(mavenProject, oldMavenProject)) {
       String projectUri = getNormalizedProjectPath(mavenProject);
-      notifyClient(Commands.CLIENT_UPDATE_PROJECT_CONFIG, projectUri);
+      notifyClient(Notifications.UPDATE_PROJECT_CONFIG, projectUri);
     } else if (!mavenProject
         .getMavenProjectModules()
         .equals(oldMavenProject.getMavenProjectModules())) {
@@ -68,7 +68,7 @@ public class MavenProjectConfigurator implements IMavenProjectChangedListener {
     updateInfo.setAdded(findAddedModules(mavenProject, oldMavenProject));
     updateInfo.setRemoved(findRemovedModules(mavenProject, oldMavenProject));
 
-    notifyClient(Commands.CLIENT_UPDATE_MAVEN_MODULE, updateInfo);
+    notifyClient(Notifications.UPDATE_MAVEN_MODULE, updateInfo);
   }
 
   private List<String> findRemovedModules(
@@ -94,7 +94,7 @@ public class MavenProjectConfigurator implements IMavenProjectChangedListener {
   private void notifyClient(String commandId, Object parameters) {
     try {
       JDTLanguageServer ls = JavaLanguageServerPlugin.getInstance().getProtocol();
-      ls.getClientConnection().executeClientCommand(commandId, parameters);
+      ls.getClientConnection().sendNotification(commandId, parameters);
     } catch (Exception e) {
       JavaLanguageServerPlugin.logException(
           "An exception occurred while reporting project updating", e);

--- a/org-eclipse-che-jdt-ls-extension/jdt.ls.extension.core/src/main/java/org/eclipse/che/jdt/ls/extension/core/internal/pom/ReImportMavenProjectsHandler.java
+++ b/org-eclipse-che-jdt-ls-extension/jdt.ls.extension.core/src/main/java/org/eclipse/che/jdt/ls/extension/core/internal/pom/ReImportMavenProjectsHandler.java
@@ -18,7 +18,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import org.eclipse.che.jdt.ls.extension.api.Commands;
+import org.eclipse.che.jdt.ls.extension.api.Notifications;
 import org.eclipse.che.jdt.ls.extension.api.dto.ReImportMavenProjectsCommandParameters;
 import org.eclipse.che.jdt.ls.extension.core.internal.GsonUtils;
 import org.eclipse.core.resources.IFile;
@@ -116,7 +116,7 @@ public class ReImportMavenProjectsHandler {
       }
       try {
         JDTLanguageServer ls = JavaLanguageServerPlugin.getInstance().getProtocol();
-        ls.getClientConnection().executeClientCommand(Commands.CLIENT_UPDATE_PROJECT, projectUri);
+        ls.getClientConnection().sendNotification(Notifications.UPDATE_PROJECT, projectUri);
       } catch (Exception e) {
         JavaLanguageServerPlugin.logException(
             "An exception occured while reporting project updating", e);


### PR DESCRIPTION
To fix https://github.com/eclipse/che/issues/11053 Using client commands leads to deadlocks when projects are large enough (see related issue in jdt.ls)
PR depends on https://github.com/eclipse/eclipse.jdt.ls/pull/779