### PR TITLE
Handle case where job managers is suspended when joining job.

### DIFF
--- a/org-eclipse-che-jdt-ls-extension/jdt.ls.extension.core/src/main/java/org/eclipse/che/jdt/ls/extension/core/internal/UpdateWorkspaceCommand.java
+++ b/org-eclipse-che-jdt-ls-extension/jdt.ls.extension.core/src/main/java/org/eclipse/che/jdt/ls/extension/core/internal/UpdateWorkspaceCommand.java
@@ -68,6 +68,12 @@ public class UpdateWorkspaceCommand {
 
     try {
       job.join(0L, pm);
+      // workaround for https://github.com/eclipse/eclipse.jdt.ls/issues/783
+      while (job.getState() == Job.WAITING || job.getState() == Job.SLEEPING) {
+        // this happens when the JobManager is suspended (a rare case). Wait a bit for it to resume.
+        Thread.sleep(100);
+        job.join(0L, pm);
+      }
     } catch (InterruptedException e) {
       JavaLanguageServerPlugin.logException(e.getMessage(), e);
       Thread.currentThread().interrupt();


### PR DESCRIPTION
Waits for the update workspace job to actually start before joining it. This should fix spurious NPE's when running udpate workspace jobs in sequence or parallel.