### PR TITLE
Fix repos and parent pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,8 +15,8 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <artifactId>maven-depmgt-pom</artifactId>
-        <groupId>org.eclipse.che.depmgt</groupId>
+        <artifactId>maven-parent-pom</artifactId>
+        <groupId>org.eclipse.che.parent</groupId>
         <version>6.11.0-SNAPSHOT</version>
     </parent>
     <groupId>org.eclipse.che.ls.jdt</groupId>
@@ -36,28 +36,6 @@
     <repositories>
         <repository>
             <releases>
-                <enabled>true</enabled>
-            </releases>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
-            <id>codenvy-public-repo</id>
-            <name>codenvy public</name>
-            <url>https://maven.codenvycorp.com/content/groups/public/</url>
-        </repository>
-        <repository>
-            <releases>
-                <enabled>false</enabled>
-            </releases>
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
-            <id>codenvy-public-snapshots-repo</id>
-            <name>codenvy public snapshots</name>
-            <url>https://maven.codenvycorp.com/content/repositories/codenvy-public-snapshots/</url>
-        </repository>
-        <repository>
-            <releases>
                 <enabled>false</enabled>
             </releases>
             <snapshots>
@@ -67,29 +45,15 @@
             <name>jdt.ls SNAPSHOTS</name>
             <url>https://ci.eclipse.org/ls/job/jdt-ls-master/ws/repository/</url>
         </repository>
+         <repository>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+			<id>oss.sonatype.org</id>
+			<url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+        </repository>
     </repositories>
-    <pluginRepositories>
-        <pluginRepository>
-            <releases>
-                <enabled>true</enabled>
-            </releases>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
-            <id>codenvy-public-repo</id>
-            <name>codenvy public</name>
-            <url>https://maven.codenvycorp.com/content/groups/public/</url>
-        </pluginRepository>
-        <pluginRepository>
-            <releases>
-                <enabled>false</enabled>
-            </releases>
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
-            <id>codenvy-public-snapshots-repo</id>
-            <name>codenvy public snapshots</name>
-            <url>https://maven.codenvycorp.com/content/repositories/codenvy-public-snapshots/</url>
-        </pluginRepository>
-    </pluginRepositories>
 </project>


### PR DESCRIPTION
This PR does two changes:
1. It uses the sonatype maven repos instead of codenvy repos
2. Changes the parent pom from che depmgmt to parent. It was always wrong to have the dependencies be the same as in che: the version of bundles we use need to be the same as in jdt.ls, not as in che. Deriving from the che parent pom still uses the same settings for formatting, etc. 
See: https://github.com/eclipse/che/issues/11182