### PR TITLE
Fixed handling of maven project dep

### DIFF
--- a/org-eclipse-che-jdt-ls-extension/jdt.ls.extension.core/src/main/java/org/eclipse/che/jdt/ls/extension/core/internal/classpath/ResolveClassPathsHandler.java
+++ b/org-eclipse-che-jdt-ls-extension/jdt.ls.extension.core/src/main/java/org/eclipse/che/jdt/ls/extension/core/internal/classpath/ResolveClassPathsHandler.java
@@ -15,6 +15,7 @@ import static java.util.Collections.emptyList;
 import static org.eclipse.che.jdt.ls.extension.core.internal.JavaModelUtil.getJavaProject;
 import static org.eclipse.che.jdt.ls.extension.core.internal.Utils.ensureNotCancelled;
 
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
@@ -141,8 +142,15 @@ public class ResolveClassPathsHandler {
     ClasspathEntry entryDTO = new ClasspathEntry();
     entryDTO.setEntryKind(entry.getEntryKind());
     switch (entry.getEntryKind()) {
-      case IClasspathEntry.CPE_SOURCE:
       case IClasspathEntry.CPE_PROJECT:
+        URI projectUri =
+            ResourcesPlugin.getWorkspace()
+                .getRoot()
+                .getProject(entry.getPath().lastSegment())
+                .getLocationURI();
+        entryDTO.setPath(ResourceUtils.fixURI(projectUri));
+        break;
+      case IClasspathEntry.CPE_SOURCE:
         entryDTO.setPath(JavaModelUtil.getFolderLocation(entry.getPath()));
         break;
       case IClasspathEntry.CPE_LIBRARY:


### PR DESCRIPTION
Fixes #80

Signed-off-by: Ivan Yonchovski <yyoncho@gmail.com>

Sample request response after change:

```
Sep 22, 2018 3:11:24 PM >> workspace/executeCommand che.jdt.ls.extension.classpathTree
Output from language server: {
  "jsonrpc": "2.0",
  "id": 14,
  "result": [
    {
      "entryKind": 3,
      "path": "file:///home/kyoncho/Sources/demo/com.dap.demo.parent/project-b/src/main/java"
    },
    {
      "entryKind": 3,
      "path": "file:///home/kyoncho/Sources/demo/com.dap.demo.parent/project-b/src/test/java"
    },
    ...
    {
      "entryKind": 5,
      "path": "org.eclipse.m2e.MAVEN2_CLASSPATH_CONTAINER",
      "children": [
        {
          "entryKind": 1,
          "path": "file:///home/kyoncho/.m2/repository/junit/junit/4.11/junit-4.11.jar"
        },
        {
          "entryKind": 1,
          "path": "file:///home/kyoncho/.m2/repository/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3.jar"
        },
        {
          "entryKind": 2,
          "path": "file:///home/kyoncho/Sources/demo/com.dap.demo.parent/project-a"
        }
      ]
    }
  ]
}
```
