### PR TITLE
Consume che-ls-jdt as jdt.ls extension

### DIFF
--- a/org-eclipse-che-jdt-ls-extension/jdt.ls.extension.api/META-INF/MANIFEST.MF
+++ b/org-eclipse-che-jdt-ls-extension/jdt.ls.extension.api/META-INF/MANIFEST.MF
@@ -6,6 +6,4 @@ Bundle-Version: 0.0.1.qualifier
 Export-Package: org.eclipse.che.jdt.ls.extension.api,
  org.eclipse.che.jdt.ls.extension.api.dto
 Import-Package: org.eclipse.lsp4j,
- org.eclipse.lsp4j.jsonrpc.messages,
- org.eclipse.xtext.xbase.lib;version="2.13.0",
- org.eclipse.xtext.xbase.lib.util;version="2.13.0"
+ org.eclipse.lsp4j.jsonrpc.messages

--- a/org-eclipse-che-jdt-ls-extension/jdt.ls.extension.core/META-INF/MANIFEST.MF
+++ b/org-eclipse-che-jdt-ls-extension/jdt.ls.extension.core/META-INF/MANIFEST.MF
@@ -7,8 +7,6 @@ Bundle-Activator: org.eclipse.che.jdt.ls.extension.core.internal.ExtensionActiva
 Import-Package: com.google.common.base;version="15.0.0",
  com.google.common.reflect;version="15.0.0",
  com.google.gson,
- org.apache.commons.io,
- org.apache.commons.lang3.tuple;version="3.1.0",
  org.eclipse.che.jdt.ls.extension.api,
  org.eclipse.che.jdt.ls.extension.api.dto,
  org.eclipse.core.internal.resources,
@@ -29,9 +27,9 @@ Import-Package: com.google.common.base;version="15.0.0",
 Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.jdt.core,
  org.eclipse.m2e.core,
+ org.eclipse.text;bundle-version="3.6.0",
  org.eclipse.m2e.maven.runtime,
  org.eclipse.jdt.ls.core,
- org.eclipse.jface.text,
  org.eclipse.jdt.core.manipulation
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8

--- a/org-eclipse-che-jdt-ls-extension/jdt.ls.extension.core/build.properties
+++ b/org-eclipse-che-jdt-ls-extension/jdt.ls.extension.core/build.properties
@@ -1,5 +1,6 @@
 source.. = src/main/java/
 output.. = target/classes/
-bin.includes = plugin.xml,\
-               META-INF/,\
+bin.includes = META-INF/,\
+               .,\
+               plugin.xml,\
                .

--- a/org-eclipse-che-jdt-ls-extension/jdt.ls.extension.core/pom.xml
+++ b/org-eclipse-che-jdt-ls-extension/jdt.ls.extension.core/pom.xml
@@ -23,6 +23,13 @@
     <artifactId>jdt.ls.extension.core</artifactId>
     <packaging>eclipse-plugin</packaging>
     <name>Che Ls Jdt :: Extension :: Core</name>
+    <dependencies>
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>2.5</version>
+        </dependency>
+    </dependencies>
     <build>
         <plugins>
             <plugin>

--- a/org-eclipse-che-jdt-ls-extension/jdt.ls.extension.test/META-INF/MANIFEST.MF
+++ b/org-eclipse-che-jdt-ls-extension/jdt.ls.extension.test/META-INF/MANIFEST.MF
@@ -33,5 +33,4 @@ Require-Bundle: org.eclipse.jdt.junit4.runtime;bundle-version="1.1.0",
  org.eclipse.lsp4j,
  org.eclipse.lsp4j.jsonrpc,
  org.eclipse.xtend.lib,
- org.eclipse.xtext.xbase.lib,
  org.eclipse.jdt.launching

--- a/org-eclipse-che-jdt-ls-extension/jdt.ls.extension.test/pom.xml
+++ b/org-eclipse-che-jdt-ls-extension/jdt.ls.extension.test/pom.xml
@@ -24,4 +24,11 @@
     <packaging>eclipse-test-plugin</packaging>
     <name>Che Ls Jdt :: Extension :: Test</name>
     <description>jdt.ls.extension Test Plugin</description>
+    <dependencies>
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>2.5</version>
+        </dependency>
+    </dependencies>
 </project>


### PR DESCRIPTION
- Cleaned unused bundles;
- Added a dependency for commons.io;
- Replaced bandle `org.eclipse.jface.text` with `org.eclipse.text`

Related issue: https://github.com/theia-ide/theia/issues/2849

Signed-off-by: Valeriy Svydenko <vsvydenk@redhat.com>