### PR TITLE
Depend on 0.27 release of jdt.ls

### DIFF
--- a/org-eclipse-che-jdt-ls-extension/pom.xml
+++ b/org-eclipse-che-jdt-ls-extension/pom.xml
@@ -50,8 +50,7 @@
     <repositories>
         <repository>
             <id>jdt.ls</id>
-            <url>http://download.eclipse.org/jdtls/snapshots/repository/latest/</url>
-            <layout>p2</layout>
+            <url>https://repo.eclipse.org/content/repositories/jdtls-releases</url>
         </repository>
     </repositories>
     <build>
@@ -146,7 +145,7 @@
                         <artifact>
                             <groupId>org.eclipse.jdt.ls</groupId>
                             <artifactId>org.eclipse.jdt.ls.tp</artifactId>
-                            <version>0.26.0.20181009132402</version>
+                            <version>0.27.0.20181114223651</version>
                         </artifact>
                     </target>
                     <environments>

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>maven-parent-pom</artifactId>
         <groupId>org.eclipse.che.parent</groupId>
-        <version>6.12.1</version>
+        <version>6.13.0</version>
     </parent>
     <groupId>org.eclipse.che.ls.jdt</groupId>
     <artifactId>che-ls-jdt-parent</artifactId>
@@ -34,21 +34,18 @@
         <url>https://github.com/eclipse/che-ls-jdt</url>
     </scm>
     <repositories>
-        <repository>
-            <releases>
-                <enabled>false</enabled>
-            </releases>
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
-            <id>jdt-ls-snapshots</id>
+        <!-- turn this repo on if you need to work against "latest" 
+        repository>
+             <id>jdt-ls-snapshots</id>
             <name>jdt.ls SNAPSHOTS</name>
-            <url>https://ci.eclipse.org/ls/job/jdt-ls-master/ws/repository/</url>
-        </repository>
+            <url>http://download.eclipse.org/jdtls/snapshots/repository/latest/</url>
+            <layout>p2</layout>
+        </repository-->
         <repository>
             <id>jdt-ls-releases</id>
-            <name>jdt.ls RELEAES</name>
-            <url>https://repo.eclipse.org/content/repositories/jdtls-releases/</url>
+            <name>jdt.ls RELEASES</name>
+            <url>http://download.eclipse.org/jdtls/milestones/0.27.0/repository</url>
+            <layout>p2</layout>
         </repository>
         <repository>
             <releases>


### PR DESCRIPTION
Fix for https://github.com/eclipse/che/issues/11947
* update to 0.27 release for target platform
* use 0.27 release repo for resolving bundle dependencies

