### PR TITLE
CRW-2 should master branch of che-ls-jdt use...

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>maven-parent-pom</artifactId>
         <groupId>org.eclipse.che.parent</groupId>
-        <version>6.13.0</version>
+        <version>6.16.0-SNAPSHOT</version>
     </parent>
     <groupId>org.eclipse.che.ls.jdt</groupId>
     <artifactId>che-ls-jdt-parent</artifactId>


### PR DESCRIPTION
CRW-2 should master branch of che-ls-jdt use latest version of che.parent, rather than a version from >6wks ago?

Change-Id: Iccf412edb99513764951d69386b0847f42043feb
Signed-off-by: nickboldt <nboldt@redhat.com>