### PR TITLE
Update to use latest jdtls 0.30.0 milestone...

### DIFF
--- a/org-eclipse-che-jdt-ls-extension/pom.xml
+++ b/org-eclipse-che-jdt-ls-extension/pom.xml
@@ -145,7 +145,7 @@
                         <artifact>
                             <groupId>org.eclipse.jdt.ls</groupId>
                             <artifactId>org.eclipse.jdt.ls.tp</artifactId>
-                            <version>0.27.0.20181114223651</version>
+                            <version>0.30.0.20181220000357</version>
                         </artifact>
                     </target>
                     <environments>

--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
         <repository>
             <id>jdt-ls-releases</id>
             <name>jdt.ls RELEASES</name>
-            <url>http://download.eclipse.org/jdtls/milestones/0.27.0/repository</url>
+            <url>http://download.eclipse.org/jdtls/milestones/0.30.0/repository</url>
             <layout>p2</layout>
         </repository>
         <repository>

--- a/pom.xml
+++ b/pom.xml
@@ -38,13 +38,13 @@
         repository>
              <id>jdt-ls-snapshots</id>
             <name>jdt.ls SNAPSHOTS</name>
-            <url>http://download.eclipse.org/jdtls/snapshots/repository/latest/</url>
+            <url>https://download.eclipse.org/jdtls/snapshots/repository/latest/</url>
             <layout>p2</layout>
         </repository-->
         <repository>
             <id>jdt-ls-releases</id>
             <name>jdt.ls RELEASES</name>
-            <url>http://download.eclipse.org/jdtls/milestones/0.30.0/repository</url>
+            <url>https://download.eclipse.org/jdtls/milestones/0.30.0/repository</url>
             <layout>p2</layout>
         </repository>
         <repository>


### PR DESCRIPTION
Update to use latest jdtls 0.30.0 milestone from 201812180348 so that we can fix this problem:

````
[ERROR] Failed to resolve target definition /home/hudson/.m2/repository/
org/eclipse/jdt/ls/org.eclipse.jdt.ls.tp/0.27.0.20181114223651/
org.eclipse.jdt.ls.tp-0.27.0.20181114223651.target: Failed to 
load p2 metadata repository from location 
http://download.eclipse.org/eclipse/updates/4.10-I-builds/: 
No repository found at http://download.eclipse.org/eclipse/updates/4.10-I-builds.
```` 
-- https://codeready-workspaces-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/view/CRW_CI/view/Pipelines/job/crw_master/57/console

Change-Id: I5ac9f37e19445f6ad8a4c6381ba435e3c4a91038
Signed-off-by: nickboldt <nboldt@redhat.com>