### PR TITLE
Update jdt.ls

### DIFF
--- a/org-eclipse-che-jdt-ls-extension/jdt.ls.extension.core/src/main/java/org/eclipse/che/jdt/ls/extension/core/internal/imports/OrganizeImportsCommand.java
+++ b/org-eclipse-che-jdt-ls-extension/jdt.ls.extension.core/src/main/java/org/eclipse/che/jdt/ls/extension/core/internal/imports/OrganizeImportsCommand.java
@@ -33,6 +33,7 @@ import org.eclipse.jdt.ls.core.internal.corrections.InnovationContext;
 import org.eclipse.jdt.ls.core.internal.corrections.proposals.CUCorrectionProposal;
 import org.eclipse.jdt.ls.core.internal.corrections.proposals.IProposalRelevance;
 import org.eclipse.jface.text.IDocument;
+import org.eclipse.lsp4j.CodeActionKind;
 import org.eclipse.lsp4j.WorkspaceEdit;
 import org.eclipse.ltk.core.refactoring.TextChange;
 import org.eclipse.text.edits.TextEdit;
@@ -117,7 +118,12 @@ public class OrganizeImportsCommand {
     try {
       InnovationContext context = new InnovationContext(cu, 0, cu.getBuffer().getLength() - 1);
       CUCorrectionProposal proposal =
-          new CUCorrectionProposal("OrganizeImports", cu, IProposalRelevance.ORGANIZE_IMPORTS) {
+          new CUCorrectionProposal(
+              "OrganizeImports",
+              CodeActionKind.SourceOrganizeImports,
+              cu,
+              null,
+              IProposalRelevance.ORGANIZE_IMPORTS) {
             @Override
             protected void addEdits(IDocument document, TextEdit editRoot) throws CoreException {
               CompilationUnit astRoot = context.getASTRoot();

--- a/org-eclipse-che-jdt-ls-extension/pom.xml
+++ b/org-eclipse-che-jdt-ls-extension/pom.xml
@@ -145,7 +145,7 @@
                         <artifact>
                             <groupId>org.eclipse.jdt.ls</groupId>
                             <artifactId>org.eclipse.jdt.ls.tp</artifactId>
-                            <version>0.27.0.20181114223651</version>
+                            <version>0.30.0.20190108171142</version>
                         </artifact>
                     </target>
                     <environments>

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>maven-parent-pom</artifactId>
         <groupId>org.eclipse.che.parent</groupId>
-        <version>6.16.0-SNAPSHOT</version>
+        <version>6.17.0-SNAPSHOT</version>
     </parent>
     <groupId>org.eclipse.che.ls.jdt</groupId>
     <artifactId>che-ls-jdt-parent</artifactId>
@@ -44,10 +44,10 @@
         <repository>
             <id>jdt-ls-releases</id>
             <name>jdt.ls RELEASES</name>
-            <url>https://download.eclipse.org/jdtls/milestones/0.27.0/repository</url>
+            <url>https://download.eclipse.org/jdtls/milestones/0.30.0/repository</url>
             <layout>p2</layout>
         </repository>
-        <repository>
+        <!-- repository>
             <releases>
                 <enabled>false</enabled>
             </releases>
@@ -56,6 +56,6 @@
             </snapshots>
             <id>oss.sonatype.org</id>
             <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
-        </repository>
+        </repository-->
     </repositories>
 </project>


### PR DESCRIPTION
This PR updates jdt.ls to version 0.30.0.20190108171142 This is necessary because the target platform of previoiusly used version has become invalid (due to integration builds being deleted).
OrganizeImportsCommand has been update to reflect a removed constructor.

Related Issue: https://github.com/eclipse/che/issues/12263